### PR TITLE
fix: export default false positives

### DIFF
--- a/lib/rules/avoid-barrel-files.js
+++ b/lib/rules/avoid-barrel-files.js
@@ -57,7 +57,12 @@ module.exports = {
         }
 
         if (n.type === 'ExportDefaultDeclaration') {
-          if (n.declaration.type === 'ObjectExpression') {
+          if (
+            n.declaration.type === 'FunctionDeclaration' ||
+            n.declaration.type === 'CallExpression'
+          ) {
+            declarations += 1;
+          } else if (n.declaration.type === 'ObjectExpression') {
             exports += n.declaration.properties.length;
           } else {
             exports += 1;

--- a/tests/lib/rules/avoid-barrel-files.js
+++ b/tests/lib/rules/avoid-barrel-files.js
@@ -51,6 +51,38 @@ ruleTester.run('avoid-barrel-files', rule, {
         let foo, bar, baz, qux, quux;
         export { foo, bar, baz, qux };
       `,
+    },
+    {
+      code: `
+        export default function Foo() {
+          return 'bar';
+        }
+      `,
+      options: [
+        {
+          amountOfExportsToConsiderModuleAsBarrel: 0,
+        },
+      ],
+    },
+    {
+      code: `
+        export default function bar() {}
+      `,
+      options: [
+        {
+          amountOfExportsToConsiderModuleAsBarrel: 0,
+        },
+      ],
+    },
+    {
+      code: `
+        export default defineFoo({});
+      `,
+      options: [
+        {
+          amountOfExportsToConsiderModuleAsBarrel: 0,
+        },
+      ],
     }
   ],
 


### PR DESCRIPTION
Fixes the false positives raised when the following config is used:

```js
'barrel-files/avoid-barrel-files': [
  'error',
  { amountOfExportsToConsiderModuleAsBarrel: 0 }
],
```

See issue #5 for more details.