### PR TITLE
feat: add allowlist option for namespace imports

### DIFF
--- a/docs/rules/avoid-namespace-import.md
+++ b/docs/rules/avoid-namespace-import.md
@@ -9,3 +9,20 @@ Examples of **incorrect** code for this rule:
 ```js
 import * as foo from 'foo';
 ```
+
+## Configuration
+
+This rule takes an optional configuration:
+
+```json
+{
+  "rules": {
+    "barrel-files/avoid-namespace-import": [
+      2,
+      {
+        "allowList": ["foo"]
+      }
+    ]
+  }
+}
+```

--- a/lib/rules/avoid-namespace-import.js
+++ b/lib/rules/avoid-namespace-import.js
@@ -15,18 +15,37 @@ module.exports = {
       recommended: true,
       url: '../../docs/rules/avoid-namespace-import.md',
     },
+    schema: [
+      {
+        allowList: {
+          type: 'array',
+          description: 'List of namespace imports to allow',
+          default: [],
+          uniqueItems: true,
+          items: {
+            type: 'string',
+          },
+        },
+      },
+    ],
   },
-  create: context => ({
-    //----------------------------------------------------------------------
-    // Public
-    //----------------------------------------------------------------------
-    ImportNamespaceSpecifier(node) {
-      if (node.parent.importKind !== 'type') {
-        context.report({
-          node,
-          message: "Avoid namespace imports, it leads to unused imports and prevents treeshaking.",
-        });
-      }
-    },
-  }),
+  create: context => {
+    const options = (context.options && context.options[0]) || {};
+    const allowList = options.allowList ?? [];
+
+
+    return{
+      //----------------------------------------------------------------------
+      // Public
+      //----------------------------------------------------------------------
+      ImportNamespaceSpecifier(node) {
+        if (node.parent.importKind !== 'type' && !allowList.includes(node.parent.source.value)) {
+          context.report({
+            node,
+            message: "Avoid namespace imports, it leads to unused imports and prevents treeshaking.",
+          });
+        }
+      },
+    }
+  },
 };

--- a/tests/lib/rules/avoid-namespace-import.js
+++ b/tests/lib/rules/avoid-namespace-import.js
@@ -26,12 +26,29 @@ ruleTester.run('avoid-namespace-import', rule, {
     'import { foo } from "foo";',
     // 'import type { foo } from "foo";',
     // 'import type * as foo from "foo";'
+    {
+      code: 'import * as foo from "foo";',
+      options: [
+        {
+          allowList: ['foo'],
+        },
+      ],
+    },
   ],
 
   invalid: [
     {
       code: 'import * as foo from "foo";',
       errors: [{ message: 'Avoid namespace imports, it leads to unused imports and prevents treeshaking.' }],
+    },
+    {
+      code: 'import * as bar from "bar";',
+      errors: [{ message: 'Avoid namespace imports, it leads to unused imports and prevents treeshaking.' }],
+      options: [
+        {
+          allowList: ['foo'],
+        },
+      ],
     },
   ],
 });


### PR DESCRIPTION
Add `allowList` option to `"avoid-namespace-import"`

This is my first time working on an eslint rule. So I don't know if I made the change correctly. Also I'm not sure how to generate the docs for this change