### PR TITLE
feat: replace resolve with oxc-resolver node binding

### DIFF
--- a/docs/rules/avoid-importing-barrel-files.md
+++ b/docs/rules/avoid-importing-barrel-files.md
@@ -26,6 +26,34 @@ This rule takes an optional configuration:
         "exportConditions": ["node", "import"],
         "mainFields": ["module", "main", "browser"],
         "extensions": [".js", ".ts", ".json", ".node"],
+        "tsconfig": {
+          "configFile": "./tsconfig.json",
+          "references": []
+        }
+      }
+    ]
+  }
+}
+```
+
+### Path Aliases
+
+The rule can accept an `alias` option whose value can be an object that matches Webpack's [resolve.alias](https://webpack.js.org/configuration/resolve/) configuration.
+
+```js
+// .eslintrc.cjs
+const path = require('path')
+
+module.exports = {
+  // ...
+  "rules": {
+    "barrel-files/avoid-importing-barrel-files": [
+      2,
+      {
+        alias: {
+          // "@/foo/bar.js" => "./src/foo/bar.js"
+          "@": [path.resolve(".", "src")]
+        }
       }
     ]
   }

--- a/lib/rules/avoid-importing-barrel-files.js
+++ b/lib/rules/avoid-importing-barrel-files.js
@@ -142,7 +142,7 @@ module.exports = {
     const tsconfig = options.tsconfig;
     const alias = options.alias;
 
-    const resolutionOptions = { exportConditions, mainFields, extensions };
+    const resolutionOptions = { exportConditions, mainFields, extensions, tsconfig, alias };
 
     const resolver = new ResolverFactory({
       tsconfig,

--- a/lib/rules/avoid-importing-barrel-files.js
+++ b/lib/rules/avoid-importing-barrel-files.js
@@ -101,6 +101,26 @@ module.exports = {
           },
         },
       },
+      // schema to match oxc-resolver's TsconfigOptions
+      {
+        tsconfig: {
+          type: 'object',
+          description: 'Options to TsconfigOptions',
+          properties: {
+            configFile: {
+              type: 'string',
+              description: 'Relative path to the configuration file'
+            },
+            references: {
+              type: 'array',
+              description: 'Typescript Project References',
+              items: {
+                type: 'string'
+              }
+            }
+          }
+        }
+      },
     ],
   },
   create(context) {
@@ -111,10 +131,12 @@ module.exports = {
     const exportConditions = options.exportConditions ?? ["node", "import"];
     const mainFields = options.mainFields ?? ["module", "browser", "main"];
     const extensions = options.extensions ?? [".js", ".ts", ".tsx", ".jsx", ".json", ".node"];
+    const tsconfig = options.tsconfig;
 
     const resolutionOptions = { exportConditions, mainFields, extensions };
 
     const resolver = new ResolverFactory({
+      tsconfig,
       conditionNames: exportConditions,
       mainFields,
       extensions

--- a/lib/rules/avoid-importing-barrel-files.js
+++ b/lib/rules/avoid-importing-barrel-files.js
@@ -9,10 +9,11 @@
 const { readFileSync } = require('fs');
 const { builtinModules } = require('module');
 const {
-  resolve,
   count_module_graph_size,
   is_barrel_file,
 } = require('eslint-barrel-file-utils/index.cjs');
+
+const { ResolverFactory } = require('oxc-resolver');
 
 /**
  * @fileoverview Avoid importing barrel files
@@ -24,6 +25,16 @@ const {
 //------------------------------------------------------------------------------
 
 const cache = {};
+
+// custom error class to emulate oxc_resolver ResolveError enum.
+// `errorVariant` can be equal to a `ResolveError` enum variant.
+class ResolveError extends Error {
+  constructor(errorVariant = null, message = "") {
+    super(message);
+    this.errorVariant = errorVariant;
+    this.message = message;
+  }
+}
 
 module.exports = {
   meta: {
@@ -103,6 +114,12 @@ module.exports = {
 
     const resolutionOptions = { exportConditions, mainFields, extensions };
 
+    const resolver = new ResolverFactory({
+      conditionNames: exportConditions,
+      mainFields,
+      extensions
+    });
+
     /**
      * @param {string} specifier
      * @returns {boolean}
@@ -130,15 +147,34 @@ module.exports = {
 
         let resolvedPath;
         try {
-          resolvedPath = resolve(currentFileName, moduleSpecifier, resolutionOptions);
-        } catch (e) {
-          if (debug) {
-            console.error(`Failed to resolve "${moduleSpecifier}" from "${currentFileName}": \n\n${e.stack}`);
+          resolvedPath = resolver.sync(currentFileName, moduleSpecifier);
+
+          if (resolvedPath.error) {
+            // assuming ResolveError::NotFound if ResolveResult's path value is None
+            if (!resolvedPath.path) {
+              throw new ResolveError("NotFound", resolvedPath.error);
+            }
+            
+            throw new ResolveError(null, resolvedPath.error);
           }
-          return;
+        } catch (e) {
+          if (!debug) {
+            return
+          }
+
+          if (e instanceof ResolveError) {
+            switch (e.errorVariant) {
+              case "NotFound":
+                console.error(`Failed to resolve "${moduleSpecifier}" from "${currentFileName}": \n\n${e.stack}`);
+              default:
+                console.error(`${e.message}: \n\n${e.stack}`);
+            }
+          }
+
+          console.error(`${e}: \n\n${e.stack}`);
         }
 
-        const fileContent = readFileSync(resolvedPath, 'utf8');
+        const fileContent = readFileSync(resolvedPath.path, 'utf8');
         let isBarrelFile;
 
         /**
@@ -150,7 +186,7 @@ module.exports = {
            */
           if (!cache[moduleSpecifier]) {
             isBarrelFile = is_barrel_file(fileContent, amountOfExportsToConsiderModuleAsBarrel);
-            const moduleGraphSize = isBarrelFile ? count_module_graph_size(resolvedPath, resolutionOptions) : -1;
+            const moduleGraphSize = isBarrelFile ? count_module_graph_size(resolvedPath.path, resolutionOptions) : -1;
 
             cache[moduleSpecifier] = {
               isBarrelFile,

--- a/lib/rules/avoid-importing-barrel-files.js
+++ b/lib/rules/avoid-importing-barrel-files.js
@@ -121,6 +121,14 @@ module.exports = {
           }
         }
       },
+      // "alias" from TsconfigOptions
+      // from: https://github.com/oxc-project/oxc-resolver/blob/a662c9810cbb81302a0fa6e6d4741e81291cc93b/napi/index.d.ts#L42
+      {
+        alias: {
+          type: 'object',
+          description: 'Webpack aliases used in imports or requires'
+        }
+      }
     ],
   },
   create(context) {
@@ -132,11 +140,13 @@ module.exports = {
     const mainFields = options.mainFields ?? ["module", "browser", "main"];
     const extensions = options.extensions ?? [".js", ".ts", ".tsx", ".jsx", ".json", ".node"];
     const tsconfig = options.tsconfig;
+    const alias = options.alias;
 
     const resolutionOptions = { exportConditions, mainFields, extensions };
 
     const resolver = new ResolverFactory({
       tsconfig,
+      alias,
       conditionNames: exportConditions,
       mainFields,
       extensions

--- a/lib/rules/avoid-importing-barrel-files.js
+++ b/lib/rules/avoid-importing-barrel-files.js
@@ -121,8 +121,7 @@ module.exports = {
           }
         }
       },
-      // "alias" from TsconfigOptions
-      // from: https://github.com/oxc-project/oxc-resolver/blob/a662c9810cbb81302a0fa6e6d4741e81291cc93b/napi/index.d.ts#L42
+      // NapiResolveOptions.alias
       {
         alias: {
           type: 'object',
@@ -198,12 +197,14 @@ module.exports = {
             switch (e.errorVariant) {
               case "NotFound":
                 console.error(`Failed to resolve "${moduleSpecifier}" from "${currentFileName}": \n\n${e.stack}`);
+                break
               default:
                 console.error(`${e.message}: \n\n${e.stack}`);
             }
           }
 
           console.error(`${e}: \n\n${e.stack}`);
+          return
         }
 
         const fileContent = readFileSync(resolvedPath.path, 'utf8');

--- a/lib/rules/avoid-importing-barrel-files.js
+++ b/lib/rules/avoid-importing-barrel-files.js
@@ -7,6 +7,7 @@
 //------------------------------------------------------------------------------
 
 const { readFileSync } = require('fs');
+const path = require('path');
 const { builtinModules } = require('module');
 const {
   count_module_graph_size,
@@ -178,7 +179,7 @@ module.exports = {
 
         let resolvedPath;
         try {
-          resolvedPath = resolver.sync(currentFileName, moduleSpecifier);
+          resolvedPath = resolver.sync(path.dirname(currentFileName), moduleSpecifier);
 
           if (resolvedPath.error) {
             // assuming ResolveError::NotFound if ResolveResult's path value is None
@@ -249,7 +250,7 @@ module.exports = {
            * Its not a bare module specifier, but local module, so we need to analyze it
            */
           const isBarrelFile = is_barrel_file(fileContent, amountOfExportsToConsiderModuleAsBarrel);
-          const moduleGraphSize = isBarrelFile ? count_module_graph_size(resolvedPath, resolutionOptions) : -1;
+          const moduleGraphSize = isBarrelFile ? count_module_graph_size(resolvedPath.path, resolutionOptions) : -1;
           if (moduleGraphSize > maxModuleGraphSizeAllowed) {
             context.report({
               node: node.source,

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "bundleDependencies": [],
   "dependencies": {
     "eslint-barrel-file-utils": "^0.0.10",
+    "oxc-resolver": "^1.9.2",
     "requireindex": "^1.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "bundleDependencies": [],
   "dependencies": {
-    "eslint-barrel-file-utils": "^0.0.10",
+    "eslint-barrel-file-utils": "^0.0.11",
     "oxc-resolver": "^1.9.2",
     "requireindex": "^1.2.0"
   }


### PR DESCRIPTION
This adds [oxc-resolver](https://www.npmjs.com/package/oxc-resolver) and replaces `resolve` in the [avoid-importing-barrel-files](https://github.com/thepassle/eslint-plugin-barrel-files/blob/main/lib/rules/avoid-importing-barrel-files.js) rule.

This also adds new options to the rule:
* `tsconfig`
  * options to oxc-resolver's `TsconfigOptions`
  * `tsconfig.configFile` accepts a path to the project's `tsconfig.json` (can be a relative path)
  * `tsconfig.references` accepts TS project references.
* `alias`
  * path aliases used in the project
  * must be an object that resembles Webpack's [`resolve.alias`](https://webpack.js.org/configuration/resolve/#resolvealias).