### PR TITLE
fix(typo): supported rule named incorrectly in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,5 +10,5 @@ For more information, I recommend reading [Speeding up the JavaScript ecosystem 
 
 - [barrel-files/avoid-barrel-files](./docs/rules/avoid-barrel-files.md)
 - [barrel-files/avoid-importing-barrel-files](./docs/rules/avoid-importing-barrel-files.md)
-- [barrel-files/avoid-namespace-imports](./docs/rules/avoid-namespace-import.md)
+- [barrel-files/avoid-namespace-import](./docs/rules/avoid-namespace-import.md)
 - [barrel-files/avoid-re-export-all](./docs/rules/avoid-re-export-all.md)


### PR DESCRIPTION
I was trying this eslint plugin on a project and copy/pasted the rules from the readme. Eslint gave an error that `barrel-files/avoid-namespace-imports` didn't exist, and I figured out `imports` should be in the singular.