### PR TITLE
feat: add `allowList` to `avoid-importing-barrel-files`

### DIFF
--- a/docs/rules/avoid-importing-barrel-files.md
+++ b/docs/rules/avoid-importing-barrel-files.md
@@ -21,6 +21,7 @@ This rule takes an optional configuration:
     "barrel-files/avoid-importing-barrel-files": [
       2,
       {
+        "allowList": ["foo"],
         "maxModuleGraphSizeAllowed": 40,
         "amountOfExportsToConsiderModuleAsBarrel": 5,
         "exportConditions": ["node", "import"],

--- a/lib/rules/avoid-importing-barrel-files.js
+++ b/lib/rules/avoid-importing-barrel-files.js
@@ -180,7 +180,7 @@ module.exports = {
         const moduleSpecifier = node.source.value;
         const currentFileName = context.getFilename();
 
-        if (options.allowList.includes(moduleSpecifier)) {
+        if (options?.allowList?.includes(moduleSpecifier)) {
           return;
         }
 
@@ -201,7 +201,7 @@ module.exports = {
             if (!resolvedPath.path) {
               throw new ResolveError("NotFound", resolvedPath.error);
             }
-            
+
             throw new ResolveError(null, resolvedPath.error);
           }
         } catch (e) {

--- a/lib/rules/avoid-importing-barrel-files.js
+++ b/lib/rules/avoid-importing-barrel-files.js
@@ -49,6 +49,17 @@ module.exports = {
     },
     schema: [
       {
+        allowList: {
+          type: 'array',
+          description: 'List of modules from which to allow barrel files',
+          default: [],
+          uniqueItems: true,
+          items: {
+            type: 'string',
+          },
+        },
+      },
+      {
         maxModuleGraphSizeAllowed: {
           type: 'number',
           description: 'Maximum allowed module graph size',
@@ -168,6 +179,10 @@ module.exports = {
       ImportDeclaration(node) {
         const moduleSpecifier = node.source.value;
         const currentFileName = context.getFilename();
+
+        if (options.allowList.includes(moduleSpecifier)) {
+          return;
+        }
 
         if (node?.importKind === 'type') {
           return;


### PR DESCRIPTION
Added `allowList` to `avoid-importing-barrel-files` rule. 

## Background

There are certain libraries whose barrel file is not yet split that I'd like to use without seeing the warning. This simply adds a new `allowList` option to add module specifiers that will be ignored by the `avoid-importing-barrel-files` rule.

## Example
```js
{
  rules: {
      'barrel-files/avoid-importing-barrel-files': [
        'warn',
        { allowList: ['@foo/bar'] },
      ]
  }
}
```